### PR TITLE
Fix conversion code from MarkedString to IMarkdownString in hovers

### DIFF
--- a/src/languageFeatures.ts
+++ b/src/languageFeatures.ts
@@ -249,7 +249,7 @@ function toMarkdownString(entry: ls.MarkupContent | ls.MarkedString): monaco.IMa
 		};
 	}
 
-	return { value: '```' + entry.value + '\n' + entry.value + '\n```\n' };
+	return { value: '```' + entry.language + '\n' + entry.value + '\n```\n' };
 }
 
 function toMarkedStringArray(contents: ls.MarkupContent | ls.MarkedString | ls.MarkedString[]): monaco.IMarkdownString[] {


### PR DESCRIPTION
The conversion code for hovers ignored `MarkedString`'s `langage` property. It was incorrectly referencing its `value` property and caused the content to be rendered in a strange way. The code has been fixed to use the `language` property and now creates the code block correctly.

The problem can be reproduced and the fix verified with the `test/index.html` test page by hovering over stuff like `.float-left` on line 38 or `.highlight` on line 46.

See Microsoft/monaco-editor#805.