### PR TITLE
Remove unused IDisposable array

### DIFF
--- a/src/cssMode.ts
+++ b/src/cssMode.ts
@@ -11,14 +11,10 @@ import * as languageFeatures from './languageFeatures';
 
 import Promise = monaco.Promise;
 import Uri = monaco.Uri;
-import IDisposable = monaco.IDisposable;
 
 export function setupMode(defaults: LanguageServiceDefaultsImpl): void {
 
-	let disposables: IDisposable[] = [];
-
 	const client = new WorkerManager(defaults);
-	disposables.push(client);
 
 	const worker = (first: Uri, ...more: Uri[]): Promise<CSSWorker> => {
 		return client.getLanguageServiceWorker(...[first].concat(more));
@@ -26,14 +22,14 @@ export function setupMode(defaults: LanguageServiceDefaultsImpl): void {
 
 	let languageId = defaults.languageId;
 
-	disposables.push(monaco.languages.registerCompletionItemProvider(languageId, new languageFeatures.CompletionAdapter(worker)));
-	disposables.push(monaco.languages.registerHoverProvider(languageId, new languageFeatures.HoverAdapter(worker)));
-	disposables.push(monaco.languages.registerDocumentHighlightProvider(languageId, new languageFeatures.DocumentHighlightAdapter(worker)));
-	disposables.push(monaco.languages.registerDefinitionProvider(languageId, new languageFeatures.DefinitionAdapter(worker)));
-	disposables.push(monaco.languages.registerReferenceProvider(languageId, new languageFeatures.ReferenceAdapter(worker)));
-	disposables.push(monaco.languages.registerDocumentSymbolProvider(languageId, new languageFeatures.DocumentSymbolAdapter(worker)));
-	disposables.push(monaco.languages.registerRenameProvider(languageId, new languageFeatures.RenameAdapter(worker)));
-	disposables.push(new languageFeatures.DiagnostcsAdapter(languageId, worker));
+	monaco.languages.registerCompletionItemProvider(languageId, new languageFeatures.CompletionAdapter(worker));
+	monaco.languages.registerHoverProvider(languageId, new languageFeatures.HoverAdapter(worker));
+	monaco.languages.registerDocumentHighlightProvider(languageId, new languageFeatures.DocumentHighlightAdapter(worker));
+	monaco.languages.registerDefinitionProvider(languageId, new languageFeatures.DefinitionAdapter(worker));
+	monaco.languages.registerReferenceProvider(languageId, new languageFeatures.ReferenceAdapter(worker));
+	monaco.languages.registerDocumentSymbolProvider(languageId, new languageFeatures.DocumentSymbolAdapter(worker));
+	monaco.languages.registerRenameProvider(languageId, new languageFeatures.RenameAdapter(worker));
+	new languageFeatures.DiagnostcsAdapter(languageId, worker));
 }
 
 


### PR DESCRIPTION
There is a `IDisposable[]` that gets created in `cssMode.ts` but it doesn't seem to serve any purpose. It should be removed instead.

See Microsoft/monaco-editor#738.