### PR TITLE
Fix error Cannot read property 'getModeId' of null

### DIFF
--- a/src/languageFeatures.ts
+++ b/src/languageFeatures.ts
@@ -103,7 +103,7 @@ export class DiagnosticsAdapter {
 			.then((diagnostics) => {
 				const markers = diagnostics.map((d) => toDiagnostics(resource, d));
 				let model = editor.getModel(resource);
-				if (model.getModeId() === languageId) {
+				if (model && model.getModeId() === languageId) {
 					editor.setModelMarkers(model, languageId, markers);
 				}
 			})


### PR DESCRIPTION
When a monaco editor instance is created and destroyed shortly afterwards, the error 'Cannot read property 'getModeId' of null' occurs. As far as I could trace this issue, this happens because in `onModelAdd` a call to `setTimeout` is made with a delay of 500ms, which in turn calls `_doValidate`. If the monaco editor instance is destroyed before the callback is called, `_doValidate` tries to call `model.getModeId()`, but model is null. The little additional null-check in this PR ensures no exception is thrown if the model cannot be determined.

Unfortunately, I wasn't able to reproduce this problem using vs code playground or similar. It is easily reproducible in our angular application which uses monaco-editor@0.21.2. Here, we display a monaco editor instance within a list of editable properties on the right side of the screen. This list is re-initialized whenever the user selects a new object on the left side of the screen. If you quickly change the items selected the error occurs. I'll be happy to provide a screen recording including the Chrome dev tools console if needed.

Last but not least: Thanks for all your great work! :)